### PR TITLE
PHP 5.4 array syntax seriously everywhere *

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -16,13 +16,13 @@
  * and is licensed under the MIT license.
  */
 
-return array(
-    'service_manager' => array(
-        'invokables' => array(
+return [
+    'service_manager' => [
+        'invokables' => [
             'ZfcRbac\Collector\RbacCollector' => 'ZfcRbac\Collector\RbacCollector',
-        ),
+        ],
 
-        'factories' => array(
+        'factories' => [
             /* Factories that do not map to a class */
             'ZfcRbac\Cache'  => 'ZfcRbac\Factory\CacheFactory',
             'ZfcRbac\Guards' => 'ZfcRbac\Factory\GuardsFactory',
@@ -38,51 +38,51 @@ return array(
             'ZfcRbac\Service\AuthorizationService'               => 'ZfcRbac\Factory\AuthorizationServiceFactory',
             'ZfcRbac\View\Strategy\RedirectStrategy'             => 'ZfcRbac\Factory\RedirectStrategyFactory',
             'ZfcRbac\View\Strategy\UnauthorizedStrategy'         => 'ZfcRbac\Factory\UnauthorizedStrategyFactory',
-        )
-    ),
+        ]
+    ],
 
-    'view_helpers' => array(
-        'factories' => array(
+    'view_helpers' => [
+        'factories' => [
             'ZfcRbac\View\Helper\IsGranted' => 'ZfcRbac\Factory\IsGrantedViewHelperFactory'
-        ),
-        'aliases' => array(
+        ],
+        'aliases' => [
             'isGranted' => 'ZfcRbac\View\Helper\IsGranted'
-        )
-    ),
+        ]
+    ],
 
-    'controller_plugins' => array(
-        'factories' => array(
+    'controller_plugins' => [
+        'factories' => [
             'ZfcRbac\Mvc\Controller\Plugin\IsGranted' => 'ZfcRbac\Factory\IsGrantedPluginFactory'
-        ),
-        'aliases' => array(
+        ],
+        'aliases' => [
             'isGranted' => 'ZfcRbac\Mvc\Controller\Plugin\IsGranted'
-        )
-    ),
+        ]
+    ],
 
-    'view_manager' => array(
-        'template_path_stack' => array(__DIR__ . '/../view'),
-    ),
+    'view_manager' => [
+        'template_path_stack' => [__DIR__ . '/../view'],
+    ],
 
-    'zenddevelopertools' => array(
-        'profiler' => array(
-            'collectors' => array(
+    'zenddevelopertools' => [
+        'profiler' => [
+            'collectors' => [
                 'zfc_rbac' => 'ZfcRbac\Collector\RbacCollector',
-            ),
-        ),
-        'toolbar' => array(
-            'entries' => array(
+            ],
+        ],
+        'toolbar' => [
+            'entries' => [
                 'zfc_rbac' => 'zend-developer-tools/toolbar/zfc-rbac',
-            ),
-        ),
-    ),
+            ],
+        ],
+    ],
 
-    'zfc_rbac' => array(
-        'unauthorized_strategy' => array(),
-        'redirect_strategy'     => array(),
+    'zfc_rbac' => [
+        'unauthorized_strategy' => [],
+        'redirect_strategy'     => [],
 
         // Plugin managers
-        'guard_manager'               => array(),
-        'role_provider_manager'       => array(),
-        'permission_provider_manager' => array()
-    )
-);
+        'guard_manager'               => [],
+        'role_provider_manager'       => [],
+        'permission_provider_manager' => []
+    ]
+];

--- a/config/zfc_rbac.global.php.dist
+++ b/config/zfc_rbac.global.php.dist
@@ -20,8 +20,8 @@
  * Copy-paste this file to your config/autoload folder (don't forget to remove the .dist extension!)
  */
 
-return array(
-    'zfc_rbac' => array(
+return [
+    'zfc_rbac' => [
         /**
          * Key that is used to fetch the identity provider
          *
@@ -59,13 +59,13 @@ return array(
          *
          * You must comply with the various options of guards. The format must be of the following format:
          *
-         *      'guards' => array(
-         *          'ZfcRbac\Guard\RouteGuard' => array(
+         *      'guards' => [
+         *          'ZfcRbac\Guard\RouteGuard' => [
          *              // options
-         *          )
-         *      )
+         *          ]
+         *      ]
          */
-        // 'guards' => array(),
+        // 'guards' => [],
 
         /**
          * As soon as one rule for either route or controller is specified, a guard will be automatically
@@ -85,14 +85,14 @@ return array(
          * It must be an array of array that contains configuration for each role provider. Each provider config
          * must follow the following format:
          *
-         *      'ZfcRbac\Role\InMemoryRoleProvider' => array(
+         *      'ZfcRbac\Role\InMemoryRoleProvider' => [
          *          'role1',
          *          'children' => 'parent'
-         *      )
+         *      ]
          *
          * Supported options depend of the role provider, so please refer to the official documentation
          */
-        'role_providers' => array(),
+        'role_providers' => [],
 
         /**
          * Configuration for permission providers
@@ -100,29 +100,29 @@ return array(
          * It must be an array of array that contains configuration for each permission provider. Each provider
          * config must follow the following format:
          *
-         *      'ZfcRbac\Permission\InMemoryRoleProvider' => array(
-         *          'permission1' => array('role1', 'role2')
-         *      )
+         *      'ZfcRbac\Permission\InMemoryRoleProvider' => [
+         *          'permission1' => ['role1', 'role2']
+         *      ]
          *
          * Supported options depend of the permission provider, so please refer to the official documentation
          */
-        'permission_providers' => array(),
+        'permission_providers' => [],
 
         /**
          * Configure the unauthorized strategy. It is used to render a template whenever a user is unauthorized
          */
-        'unauthorized_strategy' => array(
+        'unauthorized_strategy' => [
             /**
              * Set the template name to render
              */
             // 'template' => 'error/403'
-        ),
+        ],
 
         /**
          * Configure the redirect strategy. It is used to redirect the user to another route when a user is
          * unauthorized
          */
-        'redirect_strategy' => array(
+        'redirect_strategy' => [
             /**
              * Set the route to redirect (of course, it must exist!)
              */
@@ -139,7 +139,7 @@ return array(
              * the previous uri is appended
              */
             // 'previous_uri_query_key' => 'redirectTo'
-        ),
+        ],
 
         /**
          * Cache options used by role and permission providers
@@ -149,14 +149,14 @@ return array(
          *
          * @see http://framework.zend.com/manual/2.2/en/modules/zend.cache.storage.adapter.html#quick-start
          */
-        // 'cache' => array()|string,
+        // 'cache' => []|string,
 
         /**
          * Various plugin managers for guards, role providers and permission providers. Each of them must
          * follow a common plugin manager config format, and can be used to create your custom objects
          */
-        // 'guard_manager'               => array(),
-        // 'role_provider_manager'       => array(),
-        // 'permission_provider_manager' => array()
-    )
-);
+        // 'guard_manager'               => [],
+        // 'role_provider_manager'       => [],
+        // 'permission_provider_manager' => []
+    ]
+];

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -15,15 +15,15 @@ By default, ZfcRbac internally uses the `Zend\Authentication\AuthenticationServi
 not). Therefore, you must register this service in your application by adding those lines in your `module.config.php` file:
 
 ```php
-return array(
-    'service_manager' => array(
-        'factories' => array(
+return [
+    'service_manager' => [
+        'factories' => [
 	        'Zend\Authentication\AuthenticationService' => function($sm) {
 	            // Create your authentication service!
 	        }
-	    )
-    )
-);
+	    ]
+    ]
+];
 ```
 
 ZfcRbac is flexible enough to use something else than the built-in `AuthenticationService`, by specifying custom
@@ -35,15 +35,15 @@ A guard allows to block access to routes and/or controllers using a simple synta
 grants access to any route that begins with `admin` to the `admin` role only:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-	        'ZfcRbac\Guard\RouteGuard' => array(
-                'admin/*' => array('admin')
-	        )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'guards' => [
+	        'ZfcRbac\Guard\RouteGuard' => [
+                'admin/*' => ['admin']
+	        ]
+        ]
+    ]
+];
 ```
 
 ZfcRbac have several built-in guards, and you can also register your own guards. For more information, refer
@@ -59,16 +59,16 @@ This configuration creates an "admin" role and a "member" role whose parent is "
 all the permissions of *member* role.
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
-	        'ZfcRbac\Role\InMemoryRoleProvider' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
+	        'ZfcRbac\Role\InMemoryRoleProvider' => [
 	            'admin',
 		        'member' => 'admin'
-	        )
-	    )
-    )
-);
+	        ]
+	    ]
+    ]
+];
 ```
 
 ZfcRbac have several built-in role providers, and you can also register your own role providers. For more information,
@@ -83,16 +83,16 @@ is granted to "admin" role. Because of the inheritance of roles, "edit" permissi
 role (because "admin" is a parent of "member" role).
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-	        'ZfcRbac\Permission\InMemoryPermissionProvider' => array(
-	            'edit'   => array('member'),
-		        'delete' => array('admin')
-	        )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+	        'ZfcRbac\Permission\InMemoryPermissionProvider' => [
+	            'edit'   => ['member'],
+		        'delete' => ['admin']
+	        ]
+        ]
+    ]
+];
 ```
 
 ZfcRbac have several built-in permission providers, and you can also register your own permission providers. For

--- a/docs/03. Guards.md
+++ b/docs/03. Guards.md
@@ -43,11 +43,11 @@ protection can be quite frustrating. You can change it in ZfcRbac config, as fol
 ```php
 use ZfcRbac\Guard\GuardInterface;
 
-return array(
-    'zfc_rbac' => array(
+return [
+    'zfc_rbac' => [
         'protection_policy' => GuardInterface::POLICY_ALLOW
-    )
-);
+    ]
+];
 ```
 
 Now, the "login" route will still be accessible to anyone, eventhough you have not explicitely defined a rule.
@@ -57,13 +57,13 @@ Now, the "login" route will still be accessible to anyone, eventhough you have n
 ZfcRbac comes with two guards: RouteGuard and ControllerGuard. All guards must be added in the `guards` subkey:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
+return [
+    'zfc_rbac' => [
+        'guards' => [
             // Guards config here!
-        )
-    )
-);
+        ]
+    ]
+];
 ```
 
 Because of the way Zend Framework 2 handles config, you can without problem define some rules in one module, and
@@ -79,16 +79,16 @@ The RouteGuard allows to protect a route or a hierarchy of route. You must provi
 where the key is a route pattern, and value an array of role names:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\RouteGuard' => array(
-                'admin/*' => array('admin'),
-                'login'   => array('guest')
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\RouteGuard' => [
+                'admin/*' => ['admin'],
+                'login'   => ['guest']
+            ]
+        ]
+    ]
+];
 ```
 
 Those rules grant access to all admin routes to users that have the "admin" role, and grant access to the "login"
@@ -99,15 +99,15 @@ route to users that have the "guest" role (eg.: most likely unauthenticated user
 You can also use the wildcard character for roles:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\RouteGuard' => array(
-                'home' => array('*')
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\RouteGuard' => [
+                'home' => ['*']
+            ]
+        ]
+    ]
+];
 ```
 
 This rule grants access to the "home" route to anyone.
@@ -119,18 +119,18 @@ This rule grants access to the "home" route to anyone.
 The ControllerGuard allows to protect a controller. You must provide an array of array:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\ControllerGuard' => array(
-                array(
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\ControllerGuard' => [
+                [
                     'controller' => 'MyController',
-                    'roles'      => array('guest', 'member')
-                )
-            )
-        )
-    )
-);
+                    'roles'      => ['guest', 'member']
+                ]
+            ]
+        ]
+    ]
+];
 ```
 
 Those rules grant access to each actions of the MyController controller to users that have either the "guest" or
@@ -141,41 +141,41 @@ As for RouteGuard, you can use a wildcard (*) character for roles.
 You can also specify optional actions, so that the rule only apply to one or several actions:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\ControllerGuard' => array(
-                array(
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\ControllerGuard' => [
+                [
                     'controller' => 'MyController',
-                    'actions'    => array('read', 'edit'),
-                    'roles'      => array('guest', 'member')
-                )
-            )
-        )
-    )
-);
+                    'actions'    => ['read', 'edit'],
+                    'roles'      => ['guest', 'member']
+                ]
+            ]
+        ]
+    ]
+];
 ```
 
 You can combine a generic rule and a specific action rule for the same controller, as follow:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\ControllerGuard' => array(
-                array(
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\ControllerGuard' => [
+                [
                     'controller' => 'PostController',
-                    'roles'      => array('member')
-                ),
-                array(
+                    'roles'      => ['member']
+                ],
+                [
                     'controller' => 'PostController',
-                    'actions'    => array('delete'),
-                    'roles'      => array('admin')
-                )
-            )
-        )
-    )
-);
+                    'actions'    => ['delete'],
+                    'roles'      => ['admin']
+                ]
+            ]
+        ]
+    ]
+];
 ```
 
 Those rules grant access to each actions of the controller to users that have the "member" role, but restrict the
@@ -204,7 +204,7 @@ class IpGuard extends AbstractGuard
     /**
      * List of IPs to blacklist
      */
-    protected $ipAddresses = array();
+    protected $ipAddresses = [];
 
     /**
      * @param array $ipAddresses
@@ -249,15 +249,15 @@ However, for this to work, we must register the newly created guard to the guard
 following code in your config:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guard_manager' => array(
-            'factories' => array(
+return [
+    'zfc_rbac' => [
+        'guard_manager' => [
+            'factories' => [
                 'Application\Guard\IpGuard' => 'Application\Factory\IpGuardFactory'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 The `guard_manager` config follows a conventional service manager config format.
@@ -304,14 +304,14 @@ Now, we just need to add the guard to the `guards` option, so that ZfcRbac execu
 your config, add the following code:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'Application\Guard\IpGuard' => array(
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'Application\Guard\IpGuard' => [
                 '87.45.66.46',
                 '65.87.35.43'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```

--- a/docs/04. Role providers.md
+++ b/docs/04. Role providers.md
@@ -34,11 +34,11 @@ If you want to implement your own identity provider, create a new class that imp
 as shown below:
 
 ```php
-return array(
-    'zfc_rbac' => array(
+return [
+    'zfc_rbac' => [
         'identity_provider' => 'MyCustomIdentityProvider'
-    )
-);
+    ]
+];
 ```
 
 The identity provider is automatically pulled from the service manager.
@@ -49,13 +49,13 @@ ZfcRbac comes with two built-in role providers: `InMemoryRoleProvider` and `Obje
 providers must be added to the `role_providers` subkey:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
             // Role providers config here!
-        )
-    )
-);
+        ]
+    ]
+];
 ```
 
 > You don't need to specify the `guest_role`: it is automatically added for you!
@@ -68,17 +68,17 @@ your config, and hence does not need any database query.
 Here is an example config that shows you all supported formats:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
-            'ZfcRbac\Role\InMemoryRoleProvider' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
+            'ZfcRbac\Role\InMemoryRoleProvider' => [
                 'admin', // with string
                 'admin' => 'member', // with string and a parent role,
                 new Role('anotherRole') // assuming Role implements RoleInterface
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 ### ObjectRepositoryRoleProvider
@@ -92,30 +92,30 @@ the whole table. You cannot do any filtering (you should create your own provide
 You can configure this provider by giving an object repository service name that is fetched from the service manager:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
-            'ZfcRbac\Role\ObjectRepositoryRoleProvider' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
+            'ZfcRbac\Role\ObjectRepositoryRoleProvider' => [
                 'object_repository' => 'App\Repository\RoleRepository'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 Or you can specify the `object_manager` and `class_name` options:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
-            'ZfcRbac\Role\ObjectRepositoryRoleProvider' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
+            'ZfcRbac\Role\ObjectRepositoryRoleProvider' => [
                 'object_manager' => 'doctrine.entitymanager.orm_default',
                 'class_name'     => 'App\Entity\Role'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 Please note that your entity fetched from the table MUST implement the `Zend\Permissions\Rbac\RoleInterface` interface.
@@ -129,27 +129,27 @@ interface.
 Then, you need to add it to the role provider manager:
 
 ```php
-return array(
-    'role_provider_manager' => array(
-            'factories' => array(
-                'Application\Role\CustomRoleProvider' => 'Application\Factory\CustomRoleProviderFactory'
-            )
-        )
-);
+return [
+    'role_provider_manager' => [
+        'factories' => [
+            'Application\Role\CustomRoleProvider' => 'Application\Factory\CustomRoleProviderFactory'
+        ]
+    ]
+];
 ```
 
 You can now use it like any other role provider:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'role_providers' => array(
-            'Application\Role\CustomRoleProvider' => array(
+return [
+    'zfc_rbac' => [
+        'role_providers' => [
+            'Application\Role\CustomRoleProvider' => [
                 // Options
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 A complete example is provided in the cookbook.

--- a/docs/05. Permission providers.md
+++ b/docs/05. Permission providers.md
@@ -26,13 +26,13 @@ ZfcRbac comes with two built-in permission providers: `InMemoryPermissionProvide
 All permission providers must be added to the `permission_providers` subkey:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
             // Permission providers config here!
-        )
-    )
-);
+        ]
+    ]
+];
 ```
 
 ### InMemoryPermissionProvider
@@ -43,16 +43,16 @@ directly in your config, and hence does not need any database query.
 Here is an example config that shows you all supported formats:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-            'ZfcRbac\Permission\InMemoryPermissionProvider' => array(
-                'edit'  => array('member'),
-                new Permission('delete', array('admin')) // assuming Permission implements PermissionInterface
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+            'ZfcRbac\Permission\InMemoryPermissionProvider' => [
+                'edit'  => ['member'],
+                new Permission('delete', ['admin']) // assuming Permission implements PermissionInterface
+            ]
+        ]
+    ]
+];
 ```
 
 ### ObjectRepositoryPermissionProvider
@@ -67,30 +67,30 @@ for production" section.
 You can configure this provider by giving an object repository service name that is fetched from the service manager:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-            'ZfcRbac\Permission\ObjectRepositoryPermissionProvider' => array(
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+            'ZfcRbac\Permission\ObjectRepositoryPermissionProvider' => [
                 'object_repository' => 'App\Repository\PermissionRepository'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 Or you can specify the `object_manager` and `class_name` options:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-            'ZfcRbac\Permission\ObjectRepositoryPermissionProvider' => array(
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+            'ZfcRbac\Permission\ObjectRepositoryPermissionProvider' => [
                 'object_manager' => 'doctrine.entitymanager.orm_default',
                 'class_name'     => 'App\Entity\Permission'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 Please note that your entity fetched from the table MUST implement the `Zend\Permissions\Rbac\PermissionInterface` interface.
@@ -104,27 +104,27 @@ To create a custom permission providers, you first need to create a class that i
 Then, you need to add it to the permission provider manager:
 
 ```php
-return array(
-    'permission_provider_manager' => array(
-            'factories' => array(
-                'Application\Permission\CustomPermissionProvider' => 'Application\Factory\CustomPermissionProviderFactory'
-            )
-        )
-);
+return [
+    'permission_provider_manager' => [
+        'factories' => [
+            'Application\Permission\CustomPermissionProvider' => 'Application\Factory\CustomPermissionProviderFactory'
+        ]
+    ]
+];
 ```
 
 You can now use it like any other permission provider:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-            'Application\Permission\CustomPermissionProvider' => array(
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+            'Application\Permission\CustomPermissionProvider' => [
                 // Options
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 A complete example is provided in the cookbook.

--- a/docs/06. Strategies.md
+++ b/docs/06. Strategies.md
@@ -52,15 +52,15 @@ public function onBootstrap(EventInterface $e)
 You can configure the strategy using the `redirect_strategy` subkey:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'redirect_strategy' => array(
+return [
+    'zfc_rbac' => [
+        'redirect_strategy' => [
             'redirect_to_route' => 'login',
             'append_previous_uri' => true,
             'previous_uri_query_key' => 'redirectTo'
-        ),
-    )
-);
+        ],
+    ]
+];
 ```
 
 If a user tries to access to an unauthorized resource (eg.: http://www.example.com/delete), he/she will be
@@ -87,13 +87,13 @@ public function onBootstrap(EventInterface $e)
 You can configure the strategy using the `unauthorized_strategy` subkey:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'unauthorized_strategy' => array(
+return [
+    'zfc_rbac' => [
+        'unauthorized_strategy' => [
             'template' => 'error/custom-403'
-        ),
-    )
-);
+        ],
+    ]
+];
 ```
 
 > By default, ZfcRbac uses a template called `error/403`.

--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -42,16 +42,16 @@ class Module
     
     public function getControllerConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                  'PostController' => function($cpm) {
                      // We assume a Service key 'PostService' here that returns the PostService Class
                      return new PostController(
                          $cpm->getServiceLocator()->get('PostService')
                      );
                  }
-            )
-        );
+            ]
+        ];
     }
 }
 ```
@@ -89,15 +89,15 @@ class Module
     
     public function getServiceConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                  'PostService' => function($sm) {
                      return new PostService(
                          $sm->get('doctrine.entitymanager.orm_default')
                      );
                  }
-            )
-        );
+            ]
+        ];
     }
 }
 ```
@@ -114,15 +114,15 @@ service. But let's go step by step:
 Assuming the application example above we can easily use ZfcRbac to guard our route using the following code:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\RouteGuard' => array(
-                'post/delete' => array('admin')
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\RouteGuard' => [
+                'post/delete' => ['admin']
+            ]
+        ]
+    ]
+];
 ```
 
 Now, any users that do not have the "admin" users will receive a 403 error (unauthorized) when trying to access
@@ -186,16 +186,16 @@ class Module
     
     public function getServiceConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                  'PostService' => function($sm) {
                      return new PostService(
                          $sm->get('doctrine.entitymanager.orm_default'),
                          $sm->get('ZfcRbac\Service\AuthorizationService') // This is new!
                      );
                  }
-            )
-        );
+            ]
+        ];
     }
 }
 ```
@@ -204,15 +204,15 @@ Of course, you have to configure a permission provider so that the Rbac containe
 your config, add the following code:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'permission_providers' => array(
-            'ZfcRbac\Permission\InMemoryPermissionProvider' => array(
-                'deletePost'  => array('admin')
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'permission_providers' => [
+            'ZfcRbac\Permission\InMemoryPermissionProvider' => [
+                'deletePost'  => ['admin']
+            ]
+        ]
+    ]
+];
 ```
 
 For more information about permission providers, please refer to [this page](/docs/05. Permission providers.md).
@@ -224,47 +224,47 @@ whole controller. For instance, assuming you have the following route config:
 
 
 ```php
-return array(
-    'router' => array(
-        'routes' => array(
-            'admin' => array(
+return [
+    'router' => [
+        'routes' => [
+            'admin' => [
                 'type'    => 'Literal',
-                'options' => array(
+                'options' => [
                     'route' => '/admin'
-                ),
+                ],
                 'may_terminate' => true,
-                'child_routes' => array(
-                    'users' => array(
+                'child_routes' => [
+                    'users' => [
                         'type' => 'Literal',
-                        'options' => array(
+                        'options' => [
                             'route' => '/users'
-                        )
-                    ),
-                    'invoices' => array(
+                        ]
+                    ],
+                    'invoices' => [
                         'type' => 'Literal',
-                        'options' => array(
+                        'options' => [
                             'route' => '/invoices'
-                        )
-                    )
-                )
-            )
-        )
-    )
-);
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+};
 ```
 
 You can quickly unauthorized access to all admin routes using the following guard:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'guards' => array(
-            'ZfcRbac\Guard\RouteGuard' => array(
-                'admin*' => array('admin')
-            )
-        )
-    )
-);
+return [
+    'zfc_rbac' => [
+        'guards' => [
+            'ZfcRbac\Guard\RouteGuard' => [
+                'admin*' => ['admin']
+            ]
+        ]
+    ]
+];
 ```
 
 ## Optimize for production
@@ -280,21 +280,21 @@ You can either specify a service key that is fetched from service manager (the r
 implement `Zend\Cache\Storage\StorageInterface`):
 
 ```php
-return array(
-    'zfc_rbac' => array(
+return [
+    'zfc_rbac' => [
         'cache' => 'myCache'
-    )
-);
+    ]
+];
 ```
 
 Or using a `Zend\Cache\Storage\StorageFactory::factory` compliant config:
 
 ```php
-return array(
-    'zfc_rbac' => array(
-        'cache' => array(
+return [
+    'zfc_rbac' => [
+        'cache' => [
             'adapter' => 'apc'
-        )
-    )
-);
+        ]
+    ]
+];
 ```

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -20,7 +20,10 @@ use ZfcRbacTest\Util\ServiceManagerFactory;
 
 ini_set('error_reporting', E_ALL);
 
-$files = array(__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php');
+$files = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+];
 
 foreach ($files as $file) {
     if (file_exists($file)) {
@@ -36,7 +39,10 @@ if (! isset($loader)) {
 
 $loader->add('ZfcRbacTest\\', __DIR__);
 
-$configFiles = array(__DIR__ . '/TestConfiguration.php', __DIR__ . '/TestConfiguration.php.dist');
+$configFiles = [
+    __DIR__ . '/TestConfiguration.php',
+    __DIR__ . '/TestConfiguration.php.dist'
+];
 
 foreach ($configFiles as $configFile) {
     if (file_exists($configFile)) {

--- a/tests/TestConfiguration.php.dist
+++ b/tests/TestConfiguration.php.dist
@@ -16,17 +16,17 @@
  * and is licensed under the MIT license.
  */
 
-return array(
-    'modules' => array(
+return [
+    'modules' => [
         'ZfcRbac',
         'DoctrineModule',
         'DoctrineORMModule',
-    ),
-    'module_listener_options' => array(
-        'config_glob_paths' => array(
+    ],
+    'module_listener_options' => [
+        'config_glob_paths' => [
             __DIR__ . '/testing.config.php',
-        ),
-        'module_paths' => array(
-        ),
-    ),
-);
+        ],
+        'module_paths' => [
+        ],
+    ],
+];

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -16,26 +16,26 @@
  * and is licensed under the MIT license.
  */
 
-return array(
-    'zfc_rbac' => array(),
+return [
+    'zfc_rbac' => [],
 
-    'doctrine' => array(
-        'driver' => array(
-            'application_driver' => array(
+    'doctrine' => [
+        'driver' => [
+            'application_driver' => [
                 'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
                 'cache' => 'array',
-                'paths' => array(__DIR__ . '/ZfcRbacTest/Asset')
-            ),
-            'orm_default' => array(
-                'drivers' => array(
+                'paths' => [__DIR__ . '/ZfcRbacTest/Asset']
+            ],
+            'orm_default' => [
+                'drivers' => [
                     'ZfcRbacTest\Asset' => 'application_driver'
-                )
-            )
-        ),
+                ]
+            ]
+        ],
 
-        'connection' => array(
-            'orm_default' => array(
-                'params' => array(
+        'connection' => [
+            'orm_default' => [
+                'params' => [
                     'host'          => null,
                     'port'          => null,
                     'user'          => null,
@@ -45,8 +45,8 @@ return array(
                     'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
                     'path'          => null,
                     'memory'        => true,
-                ),
-            ),
-        ),
-    ),
-);
+                ],
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
- left array() notation in comments as in there it really is way more readable than the [] notation
